### PR TITLE
Add Encryption and Remote File Send

### DIFF
--- a/void_key.py
+++ b/void_key.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+
+"""
+void_key.py — Securely decrypts AES-GCM-encrypted Void Scribe .enc files.
+Prompts interactively for password (not passed as command-line argument).
+Key derivation: SHA-256 digest of password (must match encryption method).
+"""
+
+import argparse
+import getpass
+import hashlib
+import sys
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
+def decrypt_file(filepath: str, password: str) -> None:
+    try:
+        with open(filepath, 'rb') as f:
+            data = f.read()
+    except FileNotFoundError:
+        print(f"[Error] File not found: {filepath}")
+        sys.exit(1)
+    except Exception as e:
+        print(f"[Error] Failed to read file: {e}")
+        sys.exit(1)
+
+    if len(data) < 13:
+        print("[Error] File too short to contain valid AES-GCM ciphertext.")
+        sys.exit(1)
+
+    nonce, ciphertext = data[:12], data[12:]
+    key = hashlib.sha256(password.encode('utf-8')).digest()
+    aesgcm = AESGCM(key)
+
+    try:
+        decrypted = aesgcm.decrypt(nonce, ciphertext, None)
+    except Exception as e:
+        print(f"[Decryption failed] Incorrect password or corrupt ciphertext.\nDetails: {e}")
+        sys.exit(1)
+
+    try:
+        print("\n==== Decrypted Content ====\n")
+        print(decrypted.decode('utf-8'))
+    except UnicodeDecodeError:
+        print("[Decryption succeeded, but content is not valid UTF-8 text.]")
+        sys.exit(1)
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Void Key: Decrypt .enc files created by Void Scribe (AES-GCM with SHA-256 key)."
+    )
+    parser.add_argument('file', help="Path to the encrypted .enc file")
+    args = parser.parse_args()
+
+    password = getpass.getpass("Enter decryption password: ")
+    if not password:
+        print("[Error] Password cannot be empty.")
+        sys.exit(1)
+
+    decrypt_file(args.file, password)
+
+if __name__ == '__main__':
+    main()
+

--- a/void_scribe.py
+++ b/void_scribe.py
@@ -1,34 +1,91 @@
 #!/usr/bin/env python3
 """
 Void Scribe: a minimal console text editor that conceals all input and saves your hidden notes upon interruption.
+Enhanced with optional encryption, remote sending, and local deletion.
 Perfect for public writing where prying eyes must see nothing.
 """
+
 import sys
 import termios
+import argparse
+import getpass
+import subprocess
 from datetime import datetime
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+import os
 
-
-def save_inscription(content):
-    timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
-    filename = f"scripture_{timestamp}.txt"
+def save_inscription(content, filename):
     try:
-        with open(filename, 'w') as f:
+        with open(filename, 'wb') as f:
             f.write(content)
-        # After terminal restoration, reveal save status
-        print(f"\n[Enscribed {len(content)} characters into '{filename}']")
+        print(f"\n[Enscribed {len(content)} bytes into '{filename}']")
+        return True
     except Exception as e:
         print(f"\n[Error during inscription: {e}]")
+        return False
 
+def encrypt_content(content: bytes, password: str) -> bytes:
+    # AES-GCM encryption
+    # Derive key from password (simple, for demo; consider stronger KDF in production)
+    from hashlib import sha256
+    key = sha256(password.encode()).digest()  # 32 bytes key for AES-256
+
+    aesgcm = AESGCM(key)
+    nonce = os.urandom(12)  # 96-bit nonce for AESGCM
+
+    encrypted = aesgcm.encrypt(nonce, content, None)
+    # Store nonce + ciphertext together
+    return nonce + encrypted
+
+def prompt_password(confirm=False):
+    while True:
+        pwd = getpass.getpass("Enter password: ")
+        if not pwd:
+            print("Password cannot be empty.")
+            continue
+        if confirm:
+            pwd2 = getpass.getpass("Confirm password: ")
+            if pwd != pwd2:
+                print("Passwords do not match. Try again.")
+                continue
+        return pwd
+
+def send_to_remote(filename, server, remote_path, verbose=False):
+    # Using scp for simplicity (requires ssh keys or password)
+    # If password needed, user must have sshpass or similar, which is not secure.
+    # Here we just call scp and let user enter password interactively if needed.
+    remote_target = f"{server}:{remote_path}"
+    cmd = ['scp', filename, remote_target]
+    if verbose:
+        print(f"[Sending '{filename}' to remote server '{server}' at '{remote_path}']")
+    try:
+        subprocess.run(cmd, check=True)
+        if verbose:
+            print("[Remote send successful]")
+        return True
+    except subprocess.CalledProcessError as e:
+        print(f"[Error sending file to remote server: {e}]")
+        return False
 
 def main():
-    fd = sys.stdin.fileno()
+    parser = argparse.ArgumentParser(description="Void Scribe: Concealed text editor with optional encryption and remote sending.")
+    parser.add_argument('--encrypt', action='store_true', help="Encrypt the content before saving.")
+    parser.add_argument('--send', action='store_true', help="Send the saved file to a remote server via SCP.")
+    parser.add_argument('--delete-local', action='store_true', help="Delete the local file after saving (and sending if enabled).")
+    parser.add_argument('--server', type=str, help="Remote server address for sending (required if --send).")
+    parser.add_argument('--remote-path', type=str, default='~/', help="Remote path on server to save the file (default: home directory).")
+    parser.add_argument('--verbose', action='store_true', help="Enable verbose output.")
+    args = parser.parse_args()
 
-    # Preserve the original terminal incantation
+    if args.send and not args.server:
+        print("Error: --server must be specified if --send is used.")
+        sys.exit(1)
+
+    fd = sys.stdin.fileno()
     original = termios.tcgetattr(fd)
     occult = termios.tcgetattr(fd)
+    occult[3] &= ~termios.ECHO  # Disable echo
 
-    # Invoke the silence ritual: disable echo
-    occult[3] &= ~termios.ECHO
     termios.tcsetattr(fd, termios.TCSADRAIN, occult)
 
     incantation = []
@@ -41,13 +98,45 @@ def main():
                 break
             incantation.append(line)
     except KeyboardInterrupt:
-        # Ritual interrupted: proceed to inscription
+        # Interrupted, proceed to inscription
         pass
     finally:
-        # Restore original terminal echo
         termios.tcsetattr(fd, termios.TCSADRAIN, original)
-        save_inscription(''.join(incantation))
 
+    content_str = ''.join(incantation)
+    content_bytes = content_str.encode('utf-8')
+
+    # Encryption step
+    if args.encrypt:
+        if args.verbose:
+            print("[Encryption enabled]")
+        password = prompt_password(confirm=True)
+        content_bytes = encrypt_content(content_bytes, password)
+        if args.verbose:
+            print("[Content encrypted]")
+
+    timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
+    suffix = '.enc' if args.encrypt else '.txt'
+    filename = f"scripture_{timestamp}{suffix}"
+
+    saved = save_inscription(content_bytes, filename)
+
+    # Remote send step
+    if saved and args.send:
+        if args.verbose:
+            print("[Sending to remote server]")
+        success = send_to_remote(filename, args.server, args.remote_path, verbose=args.verbose)
+        if not success:
+            print("[Warning] Remote send failed.")
+
+    # Delete local file if requested
+    if saved and args.delete_local:
+        try:
+            os.remove(filename)
+            if args.verbose:
+                print(f"[Local file '{filename}' deleted]")
+        except Exception as e:
+            print(f"[Error deleting local file: {e}]")
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
## New Features
- Option to send to send to a remote SSH server
- Password Protection and Encryption
- Auto deletion of local copy 

## Full Usage Instructions
### Invisible Writing, Encryption, Remote Sending, and Auto-Deletion 
```
 ./void_scribe.py  --help
usage: void_scribe.py [-h] [--encrypt] [--send] [--delete-local]
                      [--server SERVER] [--remote-path REMOTE_PATH]
                      [--verbose]

Void Scribe: Concealed text editor with optional encryption and
remote sending.

options:
  -h, --help            show this help message and exit
  --encrypt             Encrypt the content before saving.
  --send                Send the saved file to a remote server via
                        SCP.
  --delete-local        Delete the local file after saving (and
                        sending if enabled).
  --server SERVER       Remote server address for sending (required
                        if --send).
  --remote-path REMOTE_PATH
                        Remote path on server to save the file
                        (default: home directory).
  --verbose             Enable verbose output.
``` 
### Decryption

```
 ./void_scribe.py  --help
usage: void_scribe.py [-h] [--encrypt] [--send] [--delete-local]
                      [--server SERVER] [--remote-path REMOTE_PATH]
                      [--verbose]

Void Scribe: Concealed text editor with optional encryption and
remote sending.

options:
  -h, --help            show this help message and exit
  --encrypt             Encrypt the content before saving.
  --send                Send the saved file to a remote server via
                        SCP.
  --delete-local        Delete the local file after saving (and
                        sending if enabled).
  --server SERVER       Remote server address for sending (required
                        if --send).
  --remote-path REMOTE_PATH
                        Remote path on server to save the file
                        (default: home directory).
  --verbose             Enable verbose output.
``` 
